### PR TITLE
Added verifyMessage support 

### DIFF
--- a/trezor.js
+++ b/trezor.js
@@ -175,6 +175,16 @@ Session.prototype.verifyMessage = function (address, signature, message) {
     });
 };
 
+Session.prototype.signMessage = function (address_n, message, coin) {
+    return this._typedCommonCall('SignMessage', 'MessageSignature', {
+        address_n: address_n,
+        message: message,
+        coin_name: coin.coin_name
+    }).then(function (res) {
+        return res;
+    });
+};
+
 Session.prototype.measureTx = function (inputs, outputs, coin) {
     return this._typedCommonCall('EstimateTxSize', 'TxSize', {
         inputs_count: inputs.length,


### PR DESCRIPTION
signature and message have to be in Hex format, not sure if add automatic conversion or not.
It returns a "Message verified" on success or "Signature invalid" on fail.

Note: It will fail if the message is too long (around 170chars is ok, need more test)
