### PR TITLE
Add debug link support

### DIFF
--- a/example/debug-link-example.js
+++ b/example/debug-link-example.js
@@ -1,0 +1,29 @@
+'use strict';
+
+// installed from npm
+var trezor = require('../src/index-node.js');
+
+var list = new trezor.DeviceList();
+
+// note that this works in both browser and node
+// and also in webusb; however, if with webusb,
+// user first need to "claim" the device (not demonstrated here)
+function debugPushYes(device) {
+    device.waitForSessionAndRun(function (session) {
+        // post does not wait for answer
+        // rawPost, rawRead, rawCall does not add any logic
+        return session.rawPost("DebugLinkDecision", {yes_no: true})
+    }, {debugLink: true}); // <- to mark debug link
+}
+
+list.on('connect', device => {
+
+    device.on('button', async (code) => debugPushYes(device));
+
+    device.waitForSessionAndRun(async (session) => {
+        const e = await session.typedCall("GetEntropy", "Entropy", {size: 10});
+        console.log("First random hex-string is " + e.message.entropy);
+        const f = await session.typedCall("GetEntropy", "Entropy", {size: 10});
+        console.log("Second random hex-string is " + f.message.entropy);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "node-fetch": "^1.6.0",
     "randombytes": "^2.0.1",
     "semver-compare": "1.0.0",
-    "trezor-link": "1.5.2",
+    "trezor-link": "1.6.0",
     "unorm": "^1.3.3",
     "whatwg-fetch": "0.11.0"
   },

--- a/src/device.js
+++ b/src/device.js
@@ -31,6 +31,7 @@ export type RunOptions = {
     //          it tries repeatedly
     waiting?: boolean;
     onlyOneActivity?: boolean;
+    debugLink?: boolean;
 }
 
 export default class Device extends EventEmitter {
@@ -40,7 +41,10 @@ export default class Device extends EventEmitter {
     deviceList: DeviceList;
     activityInProgress: boolean = false;
     currentSessionObject: ?Session;
+    currentDebugSessionObject: ?Session;
     connected: boolean = true;
+
+    hasDebugLink: boolean;
 
     clearSession: boolean = false;
     clearSessionTime: number = 10 * 60 * 1000; // in miliseconds
@@ -76,7 +80,7 @@ export default class Device extends EventEmitter {
     sendEvent: Event2<string, Object> = new Event2('send', this);
     _stolenEvent: Event0 = new Event0('stolen', this);
 
-    constructor(transport: Transport, descriptor: DeviceDescriptor, features: Features, deviceList: DeviceList) {
+    constructor(transport: Transport, descriptor: DeviceDescriptor, features: Features, deviceList: DeviceList, hasDebugLink: boolean) {
         super();
 
         // === immutable properties
@@ -99,6 +103,8 @@ export default class Device extends EventEmitter {
         this.features = features;
         this.connected = true;
 
+        this.hasDebugLink = hasDebugLink;
+
         this._watch();
     }
 
@@ -115,18 +121,32 @@ export default class Device extends EventEmitter {
         deviceList: DeviceList,
         onAcquire?: ?((session: Session) => void),
         onRelease?: ?((error: ?Error) => Promise<any>),
-        device: ?Device
+        device: ?Device,
+        debugLink: boolean
     ): Promise<X> {
         const session = await Device._acquire(
             transport,
             descriptor,
             deviceList,
             onAcquire,
-            device
+            device,
+            debugLink
         );
         try {
-            const features = await session.initialize();
-            return await fn(session, features.message);
+            let features: ?Features;
+            if (debugLink) {
+                // do not reload features on debug link
+                if (device == null) {
+                    throw new Error('Debug link cannot load first');
+                }
+                features = device.features;
+            } else {
+                features = (await session.initialize()).message;
+            }
+            if (features == null) {
+                throw new Error('Features unexpected null');
+            }
+            return await fn(session, features);
         } finally {
             await Device._release(descriptor, session, deviceList, onRelease);
         }
@@ -146,7 +166,7 @@ export default class Device extends EventEmitter {
                 session.release(false),
                 (res, error) => {
                     if (error == null) {
-                        deviceList.setHard(originalDescriptor.path, null);
+                        deviceList.setHard(originalDescriptor.path, null, session.debugLink);
                     }
                     return Promise.resolve();
                 }
@@ -169,18 +189,18 @@ export default class Device extends EventEmitter {
         deviceList: DeviceList,
         onAcquire?: ?((session: Session) => void),
         device: ?Device,
+        debugLink: boolean,
     ): Promise<Session> {
         return lock(() =>
             transport.acquire({
                 path: descriptor.path,
                 previous: descriptor.session,
-                checkPrevious: true,
-            }).then(res => {
-                deviceList.setHard(descriptor.path, res);
+            }, debugLink).then(res => {
+                deviceList.setHard(descriptor.path, res, debugLink);
                 return res;
             })
         ).then(result => {
-            const session = new Session(transport, result, descriptor, !!deviceList.options.debugInfo, device, deviceList.xpubDerive);
+            const session = new Session(transport, result, descriptor, !!deviceList.options.debugInfo, device, deviceList.xpubDerive, debugLink);
             if (onAcquire != null) {
                 onAcquire(session);
             }
@@ -208,9 +228,10 @@ export default class Device extends EventEmitter {
         }
         const options_ = options == null ? {} : options;
         const aggressive = !!options_.aggressive;
-        const skipFinalReload = !!options_.skipFinalReload;
         const waiting = !!options_.waiting;
 
+        const debugLink = !!options_.debugLink;
+        const skipFinalReload = !!options_.skipFinalReload || debugLink;
         const onlyOneActivity = !!options_.onlyOneActivity;
         if (onlyOneActivity && this.activityInProgress) {
             return Promise.reject(new Error('One activity already running.'));
@@ -219,7 +240,7 @@ export default class Device extends EventEmitter {
         this.activityInProgress = true;
         this._stopClearSessionTimeout();
 
-        const currentSession = this.deviceList.getSession(this.originalDescriptor.path);
+        const currentSession = this.deviceList.getSession(this.originalDescriptor.path, debugLink);
         if ((!aggressive) && (!waiting) && (currentSession != null)) {
             return Promise.reject(new Error('Device used in another window.'));
         }
@@ -229,7 +250,7 @@ export default class Device extends EventEmitter {
 
         let waitingPromise: Promise<?string> = Promise.resolve(currentSession);
         if (waiting && currentSession != null) {
-            waitingPromise = this._waitForNullSession();
+            waitingPromise = this._waitForNullSession(debugLink);
         }
 
         const runFinal = (res, error) => {
@@ -267,11 +288,21 @@ export default class Device extends EventEmitter {
                 descriptor,
                 this.deviceList,
                 (session) => {
-                    this.currentSessionObject = session;
+                    if (debugLink) {
+                        this.currentDebugSessionObject = session;
+                    } else {
+                        this.currentSessionObject = session;
+                    }
                 },
                 (error) => {
-                    this.currentSessionObject = null;
-                    this.activityInProgress = false;
+                    if (debugLink) {
+                        this.currentDebugSessionObject = null;
+                    } else {
+                        this.currentSessionObject = null;
+                    }
+                    if (!debugLink) {
+                        this.activityInProgress = false;
+                    }
                     if (error != null && this.connected) {
                         if (error.message === 'Action was interrupted.') {
                             this._stolenEvent.emit();
@@ -298,7 +329,8 @@ export default class Device extends EventEmitter {
                         return Promise.resolve();
                     }
                 },
-                this
+                this,
+                debugLink
             );
 
             return promiseFinally(
@@ -316,7 +348,7 @@ export default class Device extends EventEmitter {
                 }
                 if (error.message === WRONG_PREVIOUS_SESSION_ERROR_MESSAGE && waiting) {
                     // trying again!!!
-                    return this._waitForNullSession().then(() => {
+                    return this._waitForNullSession(debugLink).then(() => {
                         return this.run(fn, options);
                     });
                 } else {
@@ -495,11 +527,11 @@ export default class Device extends EventEmitter {
         return res;
     }
 
-    _waitForNullSession(): Promise<?string> {
+    _waitForNullSession(debugLink: boolean): Promise<?string> {
         return new Promise((resolve, reject) => {
             let onDisconnect = () => {};
             const onUpdate = () => {
-                const updatedSession = this.deviceList.getSession(this.originalDescriptor.path);
+                const updatedSession = this.deviceList.getSession(this.originalDescriptor.path, debugLink);
                 const device = this.deviceList.devices[this.originalDescriptor.path.toString()];
                 if (updatedSession == null && device != null) {
                     this.deviceList.disconnectEvent.removeListener(onDisconnect);
@@ -526,10 +558,10 @@ export default class Device extends EventEmitter {
         deviceList: DeviceList,
     ): Promise<Device> {
         // at this point I am assuming nobody else has the device
-        const descriptor = { ...originalDescriptor, session: null };
+        const descriptor: DeviceDescriptor = { ...originalDescriptor, session: null };
         return Device._run((session, features) => {
-            return new Device(transport, descriptor, features, deviceList);
-        }, transport, descriptor, deviceList);
+            return new Device(transport, descriptor, features, deviceList, !!descriptor.debug);
+        }, transport, descriptor, deviceList, null, null, null, false);
     }
 
     reloadFeatures(): Promise<boolean> {
@@ -602,12 +634,12 @@ export default class Device extends EventEmitter {
     }
 
     isUsed(): boolean {
-        const session = this.deviceList.getSession(this.originalDescriptor.path);
+        const session = this.deviceList.getSession(this.originalDescriptor.path, false);
         return session != null;
     }
 
     isUsedHere(): boolean {
-        const session = this.deviceList.getSession(this.originalDescriptor.path);
+        const session = this.deviceList.getSession(this.originalDescriptor.path, false);
         const mySession = this.currentSessionObject != null ? this.currentSessionObject.getId() : null;
         return session != null && mySession === session;
     }

--- a/src/index-browser.js
+++ b/src/index-browser.js
@@ -7,7 +7,7 @@ import 'unorm';
 import link from 'trezor-link';
 import DeviceList from './device-list';
 
-const {BridgeV1, BridgeV2, Extension, Lowlevel, WebUsb, Fallback, Parallel} = link;
+const {BridgeV2, Lowlevel, WebUsb, Fallback} = link;
 
 export {default as Session} from './session';
 export {default as UnacquiredDevice} from './unacquired-device';
@@ -32,22 +32,10 @@ DeviceList._setNode(false);
 
 DeviceList._setTransport(() => new Fallback([
     new BridgeV2(),
-    new Parallel({
-        webusb: {
-            transport: new Lowlevel(
-                new WebUsb(),
-                () => sharedWorkerFactoryWrap()
-            ),
-            mandatory: true,
-        },
-        hid: {
-            transport: new Fallback([
-                new Extension(),
-                new BridgeV1(),
-            ]),
-            mandatory: false,
-        },
-    }),
+    new Lowlevel(
+        new WebUsb(),
+        () => sharedWorkerFactoryWrap()
+    ),
 ]));
 
 import {setFetch as installersSetFetch} from './installers';

--- a/src/index-node.js
+++ b/src/index-node.js
@@ -6,7 +6,7 @@ import 'unorm';
 import link from 'trezor-link';
 import DeviceList from './device-list';
 
-const {BridgeV1, BridgeV2, Fallback} = link;
+const {BridgeV2} = link;
 
 export {default as Session} from './session';
 export {default as UnacquiredDevice} from './unacquired-device';
@@ -15,7 +15,7 @@ export {default as DescriptorStream} from './descriptor-stream';
 export {default as DeviceList} from './device-list';
 
 const fetch = require('node-fetch');
-DeviceList._setTransport(() => new Fallback([new BridgeV2(), new BridgeV1()]));
+DeviceList._setTransport(() => new BridgeV2());
 DeviceList._setNode(true);
 
 import {setFetch as installersSetFetch} from './installers';

--- a/src/unacquired-device.js
+++ b/src/unacquired-device.js
@@ -66,13 +66,13 @@ export default class UnacquiredDevice extends EventEmitter {
                 () => reject(new Error('Device disconnected before grabbing'))
             );
         });
-        const currentSession = this.deviceList.getSession(this.originalDescriptor.path);
+        const currentSession = this.deviceList.getSession(this.originalDescriptor.path, false);
         const descriptor = { ...this.originalDescriptor, session: currentSession };
 
         // if the run fails, I want to return that error, I guess
         const aggressiveRunResult = Device._run(() => {
             return true;
-        }, this.transport, descriptor, this.deviceList);
+        }, this.transport, descriptor, this.deviceList, null, null, null, false);
         return aggressiveRunResult.then(() => result);
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -846,24 +846,6 @@ bitcoin-script@^0.1.1:
     sha1 "^1.1.0"
     sha256 "^0.1.1"
 
-bitcoinjs-lib-zcash@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/bitcoinjs-lib-zcash/-/bitcoinjs-lib-zcash-3.0.0.tgz#0a36cc2145977d3861a9c859719916638e85a86c"
-  dependencies:
-    bigi "^1.4.0"
-    bip66 "^1.1.0"
-    bitcoin-ops "^1.3.0"
-    bs58check "^2.0.0"
-    create-hash "^1.1.0"
-    create-hmac "^1.1.3"
-    ecurve "^1.0.0"
-    merkle-lib "^1.0.0"
-    pushdata-bitcoin "^1.0.1"
-    randombytes "^2.0.1"
-    typeforce "^1.8.7"
-    varuint-bitcoin "^1.0.4"
-    wif "^2.0.1"
-
 bitcoinjs-lib-zcash@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/bitcoinjs-lib-zcash/-/bitcoinjs-lib-zcash-3.5.2.tgz#cd757976572106363dfe2b497e0d6c92f9a8ed98"
@@ -2043,10 +2025,6 @@ lru-cache@^4.1.3:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-merkle-lib@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/merkle-lib/-/merkle-lib-1.0.0.tgz#bd088b2c7b1026339103a0f3429ae09022cfb25c"
-
 merkle-lib@^2.0.10:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/merkle-lib/-/merkle-lib-2.0.10.tgz#82b8dbae75e27a7785388b73f9d7725d0f6f3326"
@@ -2743,12 +2721,11 @@ tough-cookie@~2.3.0:
   dependencies:
     punycode "^1.4.1"
 
-trezor-link@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/trezor-link/-/trezor-link-1.5.2.tgz#a87defc5ea4d0e882c5a8623b554673d62cdabbb"
+trezor-link@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/trezor-link/-/trezor-link-1.6.0.tgz#d79fec3e6ecf57c74c11ffbe37ebbd9118a91826"
   dependencies:
     bigi "^1.4.1"
-    bitcoinjs-lib-zcash "^3.0.0"
     ecurve "^1.0.3"
     json-stable-stringify "^1.0.1"
     node-fetch "^1.6.0"
@@ -2788,12 +2765,6 @@ typedarray@^0.0.6:
 typeforce@^1.11.3:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.12.0.tgz#ca40899919f1466d7819e37be039406beb912a2e"
-
-typeforce@^1.8.7:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.11.1.tgz#ab66f3b094856d00ed0c8913b0742d3dabfafe62"
-  dependencies:
-    inherits "^2.0.1"
 
 uid-number@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
See example in example/debug-link-example.js

This could also be used in trezor connect; I did not want to add it there because I don't see inside that much

cc @szymonlesisz 

The actual communication logic is in trezor-link; here I just added some functions for all the emitters etc; that might not be necessary in connect

(it depends on this to be merged and released in bridge - https://github.com/trezor/trezord-go/pull/117 )