### PR TITLE
GetPublicKey (getHDNode) message with "script_type"

### DIFF
--- a/src/device.js
+++ b/src/device.js
@@ -7,11 +7,12 @@ import {EventEmitter} from './events';
 import {Event0, Event1, Event2} from './flow-events';
 import Session from './session';
 import {lock} from './utils/connectionLock';
-import {harden} from './utils/hdnode';
+import {BITCOIN_COIN_INFO, harden} from './utils/hdnode';
 import * as bitcoin from 'bitcoinjs-lib-zcash';
 
 import type DeviceList from './device-list';
 import type {Features} from './trezortypes';
+import type {CoinInfo} from './utils/hdnode';
 import type {Transport, TrezorDeviceInfoWithSession as DeviceDescriptor} from 'trezor-link';
 
 // a slight hack
@@ -62,7 +63,7 @@ export default class Device extends EventEmitter {
     // comparing different calls with each other, since this is set on first call.
     integrityCheckingXpub: ?string;
     integrityCheckingXpubPath: Array<number> = [harden(49), harden(0), harden(0)];
-    integrityCheckingXpubNetwork: string | bitcoin.Network = 'bitcoin';
+    integrityCheckingXpubNetwork: string | bitcoin.Network | CoinInfo = BITCOIN_COIN_INFO;
     integrityCheckingPassphrase: ?string;
 
     disconnectEvent: Event0 = new Event0('disconnect', this);
@@ -329,7 +330,7 @@ export default class Device extends EventEmitter {
     // See the comment on top on integrityCheckingXpub.
     // This sets the xpub that we will re-check when possible (before important actions, and
     // after all action when it makes sense)
-    setCheckingXpub(integrityCheckingXpubPath: Array<number>, integrityCheckingXpub: string, integrityCheckingXpubNetwork: (string | bitcoin.Network)) {
+    setCheckingXpub(integrityCheckingXpubPath: Array<number>, integrityCheckingXpub: string, integrityCheckingXpubNetwork: string | bitcoin.Network | CoinInfo) {
         this.integrityCheckingXpubPath = integrityCheckingXpubPath;
         this.integrityCheckingXpub = integrityCheckingXpub;
         this.integrityCheckingXpubNetwork = integrityCheckingXpubNetwork;

--- a/src/session.js
+++ b/src/session.js
@@ -25,11 +25,6 @@ export type MessageResponse<T> = {
 
 export type DefaultMessageResponse = MessageResponse<Object>;
 
-/* eslint-disable no-redeclare */
-declare function coinNetwork(coin: string | bitcoin.Network): bitcoin.Network;
-declare function coinNetwork(coin: CoinInfo): CoinInfo;
-/* eslint-enable no-redeclare */
-
 //
 // Trezor device session handle. Acts as a event emitter.
 //
@@ -546,6 +541,9 @@ export function coinName(coin: string): string {
 }
 
 /* eslint-disable no-redeclare */
+declare function coinNetwork(coin: string | bitcoin.Network): bitcoin.Network;
+declare function coinNetwork(coin: CoinInfo): CoinInfo;
+
 export function coinNetwork(coin) {
     if (typeof coin !== 'string') {
         return coin;

--- a/src/session.js
+++ b/src/session.js
@@ -25,6 +25,11 @@ export type MessageResponse<T> = {
 
 export type DefaultMessageResponse = MessageResponse<Object>;
 
+/* eslint-disable no-redeclare */
+declare function coinNetwork(coin: string | bitcoin.Network): bitcoin.Network;
+declare function coinNetwork(coin: CoinInfo): CoinInfo;
+/* eslint-enable no-redeclare */
+
 //
 // Trezor device session handle. Acts as a event emitter.
 //
@@ -541,9 +546,6 @@ export function coinName(coin: string): string {
 }
 
 /* eslint-disable no-redeclare */
-declare function coinNetwork(coin: string | bitcoin.Network): bitcoin.Network;
-declare function coinNetwork(coin: CoinInfo): CoinInfo;
-
 export function coinNetwork(coin) {
     if (typeof coin !== 'string') {
         return coin;

--- a/src/utils/hdnode.js
+++ b/src/utils/hdnode.js
@@ -11,27 +11,15 @@ const curve = ecurve.getCurveByName('secp256k1');
 
 // simplified CoinInfo object passed from mytrezor
 export type CoinInfo = {
-    network: { // bitcoinjs network
-        bip32: {
-            public: number;
-            private: number;
-        };
-        dustThreshold: number;
-        messagePrefix: string;
-        pubKeyHash: number;
-        scriptHash: number;
-        wif: number;
-    };
+    network: typeof bitcoin.networks.bitcoin;
     name: string;
     segwitPubMagic: ?number;
-    segwitNativePubMagic: ?number;
 }
 
 export const BITCOIN_COIN_INFO: CoinInfo = {
     name: 'Bitcoin',
     network: bitcoin.networks.bitcoin,
     segwitPubMagic: 77429938,
-    segwitNativePubMagic: null,
 };
 
 export function bjsNode2privNode(node: bitcoin.HDNode): trezor.HDPrivNode {


### PR DESCRIPTION
solves: https://github.com/trezor/trezor.js/issues/78
Make sending "script_type" possible from FW 1.7.2/2.0.10 and only in case when extended CoinInfo* object is sent as a parameter of getHDNode method.

*CoinInfo - an object used in [mytrezor](https://github.com/satoshilabs/mytrezor/blob/develop/app/scripts/common/CoinInfo.js#L12-L41) wallet. It has additional fields (like xpub_magic_segwit_p2sh and name)

Also related to https://github.com/trezor/bitcoinjs-trezor/issues/7