### PR TITLE
zcash: don't send version_group_id if version < 3

### DIFF
--- a/src/utils/signbjstx.js
+++ b/src/utils/signbjstx.js
@@ -121,7 +121,7 @@ function signedTx2bjsTx(signedTx: MessageResponse<trezor.SignedTx>, network: bit
 
 function bjsTx2refTx(tx: bitcoin.Transaction): trezor.RefTransaction {
     const extraData = tx.getExtraData();
-    const version_group_id = bitcoin.coins.isZcashType(tx.network) ? tx.versionGroupId : null;
+    const version_group_id = bitcoin.coins.isZcashType(tx.network) && tx.version >= 3 ? tx.versionGroupId : null;
     return {
         lock_time: tx.locktime,
         version: tx.isDashSpecialTransaction() ? tx.version | tx.type << 16 : tx.version,

--- a/src/utils/signtx.js
+++ b/src/utils/signtx.js
@@ -87,7 +87,7 @@ function requestPrevTxInfo(
                 inputs_cnt: reqTx.inputs.length,
                 outputs_cnt: outputCount,
                 extra_data_len: data_.length / 2,
-                version_group_id: reqTx.version_group_id,
+                version_group_id: (reqTx.version >= 3) ? reqTx.version_group_id : null,
                 expiry: reqTx.expiry,
             };
         } else {
@@ -96,7 +96,7 @@ function requestPrevTxInfo(
                 lock_time: reqTx.lock_time,
                 inputs_cnt: reqTx.inputs.length,
                 outputs_cnt: outputCount,
-                version_group_id: reqTx.version_group_id,
+                version_group_id: (reqTx.version >= 3) ? reqTx.version_group_id : null,
             };
         }
     }


### PR DESCRIPTION
See https://github.com/trezor/trezor-firmware/issues/1177

We send `version_group_id` even when `tx.version < 3`. This should not happen. Let's fix this.
